### PR TITLE
[BT-47] Implement Password Hashing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.1.1",
         "@prisma/client": "^6.6.0",
+        "argon2": "^0.41.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "pg": "^8.14.1",
@@ -2956,6 +2957,15 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
@@ -5325,6 +5335,21 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
       "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
       "dev": true
+    },
+    "node_modules/argon2": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.41.1.tgz",
+      "integrity": "sha512-dqCW8kJXke8Ik+McUcMDltrbuAWETPyU6iq+4AhxqKphWi7pChB/Zgd/Tp/o8xRLbg8ksMj46F/vph9wnxpTzQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "node-addon-api": "^8.1.0",
+        "node-gyp-build": "^4.8.1"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -10511,6 +10536,15 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "dev": true
     },
+    "node_modules/node-addon-api": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -10538,6 +10572,17 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.1.1",
     "@prisma/client": "^6.6.0",
+    "argon2": "^0.41.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "pg": "^8.14.1",

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,6 +1,7 @@
 import { ForbiddenException, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
+import * as argon from 'argon2';
 import { LoginDto } from './dto';
 import { CreateUserDto } from 'prisma/generated/user/dto';
 
@@ -11,11 +12,13 @@ export class AuthService {
   ) { }
 
   async register(dto: CreateUserDto) {
+    const hash = await argon.hash(dto.password);
+
     try {
       const user = await this.prisma.user.create({
         data: {
           email: dto.email,
-          password: dto.password,
+          password: hash,
           firstName: dto.firstName,
           lastName: dto.lastName,
         },
@@ -43,8 +46,9 @@ export class AuthService {
       'Credentials incorrect',
     );
 
+    const pwMatches = await argon.verify(user.password, dto.password)
 
-    if (dto.password !== user.password) throw new ForbiddenException(
+    if (!pwMatches) throw new ForbiddenException(
       'Credentials incorrect',
     )
 


### PR DESCRIPTION
## What was updated:
- Integrated argon2 for secure password hashing and verification.
## Register Endpoint:
- Modified register() service method:
  - User's password is now hashed with Argon2 before being stored in the database.
  - Prisma still handles user creation.
  - Unique constraint on email still throws Credentials taken if already used.
## Login Endpoint:
- Updated login() service method:
  - Password comparison is now done using argon.verify(), matching the stored hash with the provided password.
  - If user doesn’t exist or password doesn’t match, returns Credentials incorrect.
## Notes:
- Plain text password storage is no longer used — all passwords are securely hashed.
- This improves the overall security and compliance of the authentication system.

https://bloomteq-internship-team4.atlassian.net/browse/BT-47?atlOrigin=eyJpIjoiMmUxODBlNDZjMDIwNGE2YmI5MzM1MjEwM2RmMGZkYjMiLCJwIjoiaiJ9