### PR TITLE
[BT-51] Implement role based access control (RBAC)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@casl/ability": "^6.7.3",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
@@ -688,6 +689,17 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@casl/ability": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.7.3.tgz",
+      "integrity": "sha512-A4L28Ko+phJAsTDhRjzCOZWECQWN2jzZnJPnROWWHjJpyMq1h7h9ZqjwS2WbIUa3Z474X1ZPSgW0f1PboZGC0A==",
+      "dependencies": {
+        "@ucast/mongo2js": "^1.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
+      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -4243,6 +4255,37 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@ucast/core": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.2.tgz",
+      "integrity": "sha512-ons5CwXZ/51wrUPfoduC+cO7AS1/wRb0ybpQJ9RrssossDxVy4t49QxWoWgfBDvVKsz9VXzBk9z0wqTdZ+Cq8g=="
+    },
+    "node_modules/@ucast/js": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.4.tgz",
+      "integrity": "sha512-TgG1aIaCMdcaEyckOZKQozn1hazE0w90SVdlpIJ/er8xVumE11gYAtSbw/LBeUnA4fFnFWTcw3t6reqseeH/4Q==",
+      "dependencies": {
+        "@ucast/core": "^1.0.0"
+      }
+    },
+    "node_modules/@ucast/mongo": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.3.tgz",
+      "integrity": "sha512-XcI8LclrHWP83H+7H2anGCEeDq0n+12FU2mXCTz6/Tva9/9ddK/iacvvhCyW6cijAAOILmt0tWplRyRhVyZLsA==",
+      "dependencies": {
+        "@ucast/core": "^1.4.1"
+      }
+    },
+    "node_modules/@ucast/mongo2js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.4.0.tgz",
+      "integrity": "sha512-vR9RJ3BHlkI3RfKJIZFdVktxWvBCQRiSTeJSWN9NPxP5YJkpfXvcBWAMLwvyJx4HbB+qib5/AlSDEmQiuQyx2w==",
+      "dependencies": {
+        "@ucast/core": "^1.6.1",
+        "@ucast/js": "^3.0.0",
+        "@ucast/mongo": "^2.4.0"
       }
     },
     "node_modules/@vegardit/prisma-generator-nestjs-dto": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "db:migrate:generate:name": "prisma migrate dev && npm run pretty"
   },
   "dependencies": {
+    "@casl/ability": "^6.7.3",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",

--- a/prisma/generated/permission/dto/connect-permission.dto.ts
+++ b/prisma/generated/permission/dto/connect-permission.dto.ts
@@ -1,0 +1,5 @@
+
+  export class ConnectPermissionDto {
+    id: string;
+  }
+  

--- a/prisma/generated/permission/dto/create-permission.dto.ts
+++ b/prisma/generated/permission/dto/create-permission.dto.ts
@@ -1,0 +1,12 @@
+
+import {Prisma} from '@prisma/client'
+
+
+
+
+export class CreatePermissionDto {
+  action: string;
+subject: string;
+conditions?: Prisma.InputJsonValue;
+reason?: string;
+}

--- a/prisma/generated/permission/dto/index.ts
+++ b/prisma/generated/permission/dto/index.ts
@@ -1,0 +1,4 @@
+
+export * from './connect-permission.dto';
+export * from './create-permission.dto';
+export * from './update-permission.dto';

--- a/prisma/generated/permission/dto/update-permission.dto.ts
+++ b/prisma/generated/permission/dto/update-permission.dto.ts
@@ -1,0 +1,12 @@
+
+import {Prisma} from '@prisma/client'
+
+
+
+
+export class UpdatePermissionDto {
+  action?: string;
+subject?: string;
+conditions?: Prisma.InputJsonValue;
+reason?: string;
+}

--- a/prisma/generated/permission/entities/index.ts
+++ b/prisma/generated/permission/entities/index.ts
@@ -1,0 +1,2 @@
+
+export * from './permission.entity';

--- a/prisma/generated/permission/entities/permission.entity.ts
+++ b/prisma/generated/permission/entities/permission.entity.ts
@@ -1,0 +1,15 @@
+
+import {Prisma} from '@prisma/client'
+import {Role} from '../../role/entities/role.entity'
+
+
+export class Permission {
+  id: string ;
+action: string ;
+subject: string ;
+conditions: Prisma.JsonValue  | null;
+reason: string  | null;
+createdAt: Date ;
+updatedAt: Date ;
+roles?: Role[] ;
+}

--- a/prisma/generated/role/dto/connect-role.dto.ts
+++ b/prisma/generated/role/dto/connect-role.dto.ts
@@ -1,0 +1,6 @@
+
+  export class ConnectRoleDto {
+    id?: string;
+name?: string;
+  }
+  

--- a/prisma/generated/role/dto/create-role.dto.ts
+++ b/prisma/generated/role/dto/create-role.dto.ts
@@ -1,0 +1,10 @@
+
+
+
+
+
+
+export class CreateRoleDto {
+  name: string;
+description?: string;
+}

--- a/prisma/generated/role/dto/index.ts
+++ b/prisma/generated/role/dto/index.ts
@@ -1,0 +1,4 @@
+
+export * from './connect-role.dto';
+export * from './create-role.dto';
+export * from './update-role.dto';

--- a/prisma/generated/role/dto/update-role.dto.ts
+++ b/prisma/generated/role/dto/update-role.dto.ts
@@ -1,0 +1,10 @@
+
+
+
+
+
+
+export class UpdateRoleDto {
+  name?: string;
+description?: string;
+}

--- a/prisma/generated/role/entities/index.ts
+++ b/prisma/generated/role/entities/index.ts
@@ -1,0 +1,2 @@
+
+export * from './role.entity';

--- a/prisma/generated/role/entities/role.entity.ts
+++ b/prisma/generated/role/entities/role.entity.ts
@@ -1,0 +1,15 @@
+
+import {User} from '../../user/entities/user.entity'
+import {Permission} from '../../permission/entities/permission.entity'
+
+
+export class Role {
+  id: string ;
+name: string ;
+description: string  | null;
+isDefault: boolean ;
+createdAt: Date ;
+updatedAt: Date ;
+users?: User[] ;
+permissions?: Permission[] ;
+}

--- a/prisma/generated/user/entities/user.entity.ts
+++ b/prisma/generated/user/entities/user.entity.ts
@@ -1,5 +1,5 @@
 
-
+import {Role} from '../../role/entities/role.entity'
 
 
 export class User {
@@ -12,4 +12,6 @@ firstName: string ;
 lastName: string ;
 phoneNumber: string ;
 dateOfBirth: Date ;
+role?: Role ;
+roleId: string ;
 }

--- a/prisma/migrations/20250428010251_add_role_and_permission/migration.sql
+++ b/prisma/migrations/20250428010251_add_role_and_permission/migration.sql
@@ -1,0 +1,59 @@
+/*
+  Warnings:
+
+  - Added the required column `roleId` to the `users` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "roleId" TEXT NOT NULL;
+
+-- CreateTable
+CREATE TABLE "roles" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "roles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "permissions" (
+    "id" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "conditions" JSONB,
+    "reason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "permissions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_RolePermissions" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_RolePermissions_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "roles_name_key" ON "roles"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "permissions_action_subject_key" ON "permissions"("action", "subject");
+
+-- CreateIndex
+CREATE INDEX "_RolePermissions_B_index" ON "_RolePermissions"("B");
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_roleId_fkey" FOREIGN KEY ("roleId") REFERENCES "roles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_RolePermissions" ADD CONSTRAINT "_RolePermissions_A_fkey" FOREIGN KEY ("A") REFERENCES "permissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_RolePermissions" ADD CONSTRAINT "_RolePermissions_B_fkey" FOREIGN KEY ("B") REFERENCES "roles"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,5 +36,37 @@ model User {
   phoneNumber String
   dateOfBirth DateTime @db.Date
 
+  role   Role   @relation(fields: [roleId], references: [id])
+  roleId String
+
   @@map("users")
+}
+
+model Role {
+  id          String   @id @default(uuid())
+  name        String   @unique
+  description String?
+  isDefault   Boolean  @default(false)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  users       User[]
+  permissions Permission[] @relation("RolePermissions")
+
+  @@map("roles")
+}
+
+model Permission {
+  id         String   @id @default(uuid())
+  action     String
+  subject    String
+  conditions Json?
+  reason     String?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  roles Role[] @relation("RolePermissions")
+
+  @@unique([action, subject])
+  @@map("permissions")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,10 +4,17 @@ import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
 import { UserModule } from './user/user.module';
+import { CaslModule } from './casl/casl.module';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), PrismaModule, AuthModule, UserModule],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    PrismaModule,
+    AuthModule,
+    UserModule,
+    CaslModule,
+  ],
   controllers: [],
   providers: [AppConfigService],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,6 +1,10 @@
-import { ForbiddenException, Injectable } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { LoginDto, RegisterDto } from './dto';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
@@ -11,11 +15,18 @@ export class AuthService {
     private prisma: PrismaService,
     private jwt: JwtService,
     private config: ConfigService,
-  ) { }
+  ) {}
 
   async register(dto: RegisterDto) {
-
     try {
+      const defaultRole = await this.prisma.role.findFirst({
+        where: { isDefault: true },
+      });
+
+      if (!defaultRole) {
+        throw new NotFoundException('Default role is not found.');
+      }
+
       const user = await this.prisma.user.create({
         data: {
           email: dto.email,
@@ -24,6 +35,7 @@ export class AuthService {
           lastName: dto.lastName,
           phoneNumber: dto.phoneNumber,
           dateOfBirth: dto.dateOfBirth,
+          roleId: defaultRole.id,
         },
       });
 
@@ -45,30 +57,27 @@ export class AuthService {
       },
     });
 
-    if (!user) throw new ForbiddenException(
-      'Credentials incorrect',
-    );
+    if (!user) throw new ForbiddenException('Credentials incorrect');
 
-    if (dto.password !== user.password) throw new ForbiddenException(
-      'Credentials incorrect',
-    )
+    if (dto.password !== user.password)
+      throw new ForbiddenException('Credentials incorrect');
 
     return this.signToken(user.id, user.email);
   }
 
   async signToken(
     userId: string,
-    email: string
+    email: string,
   ): Promise<{ access_token: string }> {
     const payload = {
       sub: userId,
       email,
-    }
+    };
     const secret = this.config.get('JWT_SECRET');
     const token = await this.jwt.signAsync(payload, {
       expiresIn: '30min',
       secret,
-    })
+    });
 
     return {
       access_token: token,

--- a/src/auth/decorator/get-user.decorator.ts
+++ b/src/auth/decorator/get-user.decorator.ts
@@ -1,10 +1,8 @@
-import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 export const GetUser = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
-    const request = ctx
-      .switchToHttp()
-      .getRequest();
+    const request = ctx.switchToHttp().getRequest();
     return request.user;
-  }
-)
+  },
+);

--- a/src/casl/abilities/ability-handler.interface.ts
+++ b/src/casl/abilities/ability-handler.interface.ts
@@ -1,0 +1,9 @@
+import { AppAbility } from '../casl-ability.factory/casl-ability.factory';
+
+interface IAbilityHandler {
+  handle(ability: AppAbility): boolean;
+}
+
+type AbilityHandlerCallback = (ability: AppAbility) => boolean;
+
+export type AbilityHandler = IAbilityHandler | AbilityHandlerCallback;

--- a/src/casl/abilities/decorator/check-abilities.decorator.ts
+++ b/src/casl/abilities/decorator/check-abilities.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+import { AbilityHandler } from '../ability-handler.interface';
+
+export const CHECK_ABILITY = 'check_ability';
+export const CheckAbilities = (...handlers: AbilityHandler[]) =>
+  SetMetadata(CHECK_ABILITY, handlers);

--- a/src/casl/abilities/decorator/index.ts
+++ b/src/casl/abilities/decorator/index.ts
@@ -1,0 +1,2 @@
+export * from './check-abilities.decorator';
+export * from './request-ability.decorator';

--- a/src/casl/abilities/decorator/request-ability.decorator.ts
+++ b/src/casl/abilities/decorator/request-ability.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { AppAbility } from '../../casl-ability.factory/casl-ability.factory';
+
+export const RequestAbility = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): AppAbility => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.ability;
+  },
+);

--- a/src/casl/abilities/guard/abilities.guard.ts
+++ b/src/casl/abilities/guard/abilities.guard.ts
@@ -1,0 +1,70 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import {
+  AppAbility,
+  CaslAbilityFactory,
+} from '../../casl-ability.factory/casl-ability.factory';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { AbilityHandler } from '../ability-handler.interface';
+import { CHECK_ABILITY } from '../decorator';
+
+@Injectable()
+export class AbilitiesGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private caslAbilityFactory: CaslAbilityFactory,
+    private prisma: PrismaService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const abilityHandlers =
+      this.reflector.get<AbilityHandler[]>(
+        CHECK_ABILITY,
+        context.getHandler(),
+      ) || [];
+
+    if (abilityHandlers.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const { user } = request;
+
+    if (!user) {
+      return false;
+    }
+
+    const userWithRole = await this.prisma.user.findUnique({
+      where: { id: user.id },
+      include: {
+        role: {
+          include: {
+            permissions: true,
+          },
+        },
+      },
+    });
+
+    if (!userWithRole || !userWithRole.role) {
+      return false;
+    }
+
+    const ability = this.caslAbilityFactory.createForUser(userWithRole);
+
+    request.ability = ability;
+
+    return abilityHandlers.every((handler) =>
+      this.execAbilityHandler(handler, ability),
+    );
+  }
+
+  private execAbilityHandler(
+    handler: AbilityHandler,
+    ability: AppAbility,
+  ): boolean {
+    if (typeof handler === 'function') {
+      return handler(ability);
+    }
+    return handler.handle(ability);
+  }
+}

--- a/src/casl/abilities/guard/index.ts
+++ b/src/casl/abilities/guard/index.ts
@@ -1,0 +1,1 @@
+export * from './abilities.guard';

--- a/src/casl/casl-ability.factory/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory/casl-ability.factory.ts
@@ -1,0 +1,52 @@
+import {
+  AbilityBuilder,
+  createMongoAbility,
+  MongoAbility,
+} from '@casl/ability';
+import { Injectable } from '@nestjs/common';
+import { Permission } from '../../../prisma/generated/permission/entities';
+import { Role } from '../../../prisma/generated/role/entities';
+import { User } from '../../../prisma/generated/user/entities';
+
+export enum Action {
+  Manage = 'manage',
+  Create = 'create',
+  Read = 'read',
+  Update = 'update',
+  Delete = 'delete',
+}
+
+export enum Subject {
+  User = 'User',
+  Role = 'Role',
+  Permission = 'Permission',
+  All = 'all',
+}
+
+export type AppAbility = MongoAbility<[Action, Subject | Record<string, any>]>;
+
+@Injectable()
+export class CaslAbilityFactory {
+  createForUser(user: User & { role: Role & { permissions: Permission[] } }) {
+    const { can, cannot, build } = new AbilityBuilder<AppAbility>(
+      createMongoAbility,
+    );
+
+    if (!user || !user.role || !user.role.permissions) {
+      return build();
+    }
+
+    user.role.permissions.forEach((permission) => {
+      const action = permission.action as Action;
+      const subjectType = permission.subject as Subject;
+
+      if (permission.conditions) {
+        can(action, subjectType, permission.conditions as any);
+      } else {
+        can(action, subjectType);
+      }
+    });
+
+    return build();
+  }
+}

--- a/src/casl/casl.module.ts
+++ b/src/casl/casl.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AbilitiesGuard } from './abilities/guard/abilities.guard';
+import { CaslAbilityFactory } from './casl-ability.factory/casl-ability.factory';
+
+@Module({
+  providers: [CaslAbilityFactory, AbilitiesGuard],
+  exports: [CaslAbilityFactory, AbilitiesGuard],
+})
+export class CaslModule {}

--- a/src/seed/nonprod/index.ts
+++ b/src/seed/nonprod/index.ts
@@ -1,7 +1,17 @@
 import { SeedData } from '../types';
+import { roleSeedData } from './roleSeedData';
 import { userSeedData } from './userSeedData';
+import { permissionSeedData } from './permissionSeedData';
 
 export default {
+  Role: {
+    data: roleSeedData,
+    overwrite: true,
+  },
+  Permission: {
+    data: permissionSeedData,
+    overwrite: true,
+  },
   User: {
     data: userSeedData,
     overwrite: true,

--- a/src/seed/nonprod/permissionSeedData.ts
+++ b/src/seed/nonprod/permissionSeedData.ts
@@ -1,0 +1,32 @@
+import { Action } from '../../casl/casl-ability.factory/casl-ability.factory';
+
+export const permissionSeedData = [
+  { admin: [{ action: Action.Manage, subject: 'all' }] },
+  {
+    team_lead: [
+      { action: Action.Read, subject: 'User' },
+      {
+        action: Action.Update,
+        subject: 'User',
+        conditions: { id: { $ne: '${user.id}' } },
+      },
+      { action: Action.Read, subject: 'Role' },
+    ],
+  },
+  {
+    user: [
+      {
+        action: Action.Read,
+        subject: 'User',
+        conditions: { id: { $eq: '${user.id}' } },
+      },
+      {
+        action: Action.Update,
+        subject: 'User',
+        conditions: { id: { $eq: '${user.id}' } },
+      },
+    ],
+  },
+];
+
+export type PermissionSeedData = typeof permissionSeedData;

--- a/src/seed/nonprod/roleSeedData.ts
+++ b/src/seed/nonprod/roleSeedData.ts
@@ -1,0 +1,19 @@
+export const roleSeedData = [
+  {
+    name: 'admin',
+    description: 'Administrator with full access',
+    isDefault: false,
+  },
+  {
+    name: 'team_lead',
+    description: 'Team Lead with elevated permissions',
+    isDefault: false,
+  },
+  {
+    name: 'user',
+    description: 'Regular user with limited access',
+    isDefault: true,
+  },
+];
+
+export type RoleSeedData = typeof roleSeedData;

--- a/src/seed/nonprod/userSeedData.ts
+++ b/src/seed/nonprod/userSeedData.ts
@@ -1,10 +1,25 @@
 export const userSeedData = [
   {
-    id: '00000000-0000-1000-a000-000000000010',
     email: 'johndoe@example.com',
     password: '123ABcd.',
     firstName: 'John',
     lastName: 'Doe',
+    phoneNumber: '+38761234567',
+    dateOfBirth: new Date('2000-01-02T00:00:00.000Z'),
+  },
+  {
+    email: 'janesmith@example.com',
+    password: '123ABcd.',
+    firstName: 'Jane',
+    lastName: 'Smith',
+    phoneNumber: '+38761234567',
+    dateOfBirth: new Date('2000-01-02T00:00:00.000Z'),
+  },
+  {
+    email: 'samlee@example.com',
+    password: '123ABcd.',
+    firstName: 'Sam',
+    lastName: 'Lee',
     phoneNumber: '+38761234567',
     dateOfBirth: new Date('2000-01-02T00:00:00.000Z'),
   },

--- a/src/seed/seeders/index.ts
+++ b/src/seed/seeders/index.ts
@@ -1,8 +1,12 @@
 import { PrismaClient } from '@prisma/client';
 import { seedUserData } from './seedUserData';
+import { seedRoleData } from './seedRoleData';
+import { seedPermissionData } from './seedPermissionData';
 
 export const seedAllEntities = async (client: PrismaClient) => {
   await client.$transaction(async (prisma) => {
+    await seedRoleData(prisma);
+    await seedPermissionData(prisma);
     await seedUserData(prisma);
   });
 };

--- a/src/seed/seeders/seedPermissionData.ts
+++ b/src/seed/seeders/seedPermissionData.ts
@@ -1,0 +1,51 @@
+import { Prisma } from '@prisma/client';
+import { getSeedData } from './getSeedData';
+import { PermissionSeedData } from '../nonprod/permissionSeedData';
+
+export const seedPermissionData = async (prisma: Prisma.TransactionClient) => {
+  const seedData = getSeedData('Permission') as unknown as PermissionSeedData;
+  const count = seedData.length;
+  if (!count) {
+    return;
+  }
+  for (const roleEntry of seedData) {
+    const roleName = Object.keys(roleEntry)[0];
+    const permissions = roleEntry[roleName];
+
+    const role = await prisma.role.findFirst({
+      where: { name: roleName },
+    });
+
+    if (role) {
+      for (const perm of permissions) {
+        const permission = await prisma.permission.upsert({
+          where: {
+            action_subject: {
+              action: perm.action,
+              subject: perm.subject,
+            },
+          },
+          update: {
+            action: perm.action,
+            subject: perm.subject,
+            conditions: perm.conditions || null,
+          },
+          create: {
+            action: perm.action,
+            subject: perm.subject,
+            conditions: perm.conditions || null,
+          },
+        });
+
+        await prisma.role.update({
+          where: { id: role.id },
+          data: {
+            permissions: {
+              connect: { id: permission.id },
+            },
+          },
+        });
+      }
+    }
+  }
+};

--- a/src/seed/seeders/seedRoleData.ts
+++ b/src/seed/seeders/seedRoleData.ts
@@ -1,0 +1,18 @@
+import { Prisma } from '@prisma/client';
+import { getSeedData } from './getSeedData';
+import { RoleSeedData } from '../nonprod/roleSeedData';
+
+export const seedRoleData = async (prisma: Prisma.TransactionClient) => {
+  const seedData = getSeedData('Role') as unknown as RoleSeedData;
+  const count = seedData.length;
+  if (!count) {
+    return;
+  }
+  for (const role of seedData) {
+    await prisma.role.upsert({
+      where: { name: role.name },
+      update: role,
+      create: role,
+    });
+  }
+};

--- a/src/seed/seeders/seedUserData.ts
+++ b/src/seed/seeders/seedUserData.ts
@@ -10,13 +10,22 @@ export const seedUserData = async (prisma: Prisma.TransactionClient) => {
   }
   for (const data of seedData) {
     const user = await prisma.user.findFirst({
-      where: { id: data.id },
+      where: { email: data.email },
     });
 
     if (!user) {
-      await prisma.user.create({
-        data,
+      const userRole = await prisma.role.findFirst({
+        where: { isDefault: true },
       });
+
+      if (userRole) {
+        await prisma.user.create({
+          data: {
+            ...data,
+            roleId: userRole.id,
+          },
+        });
+      }
     } else {
       await prisma.user.update({
         where: {

--- a/src/seed/seeders/seedUserData.ts
+++ b/src/seed/seeders/seedUserData.ts
@@ -3,7 +3,7 @@ import { getSeedData } from './getSeedData';
 import { UserSeedData } from '../nonprod/userSeedData';
 
 export const seedUserData = async (prisma: Prisma.TransactionClient) => {
-  const seedData = getSeedData('Admin') as unknown as UserSeedData;
+  const seedData = getSeedData('User') as unknown as UserSeedData;
   const count = seedData.length;
   if (!count) {
     return;

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,15 +1,34 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  ForbiddenException,
+} from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { GetUser } from '../auth/decorator';
 import { User } from '@prisma/client';
 import { JwtGuard } from '../auth/guard';
+import { AbilitiesGuard } from '../casl/abilities/guard/abilities.guard';
+import { CheckAbilities } from '../casl/abilities/decorator/check-abilities.decorator';
+import {
+  Action,
+  AppAbility,
+  Subject,
+} from '../casl/casl-ability.factory/casl-ability.factory';
+import { subject } from '@casl/ability';
+import { RequestAbility } from '../casl/abilities/decorator/request-ability.decorator';
 
 @UseGuards(JwtGuard)
 @Controller('user')
 export class UserController {
-  constructor(private readonly userService: UserService) { }
+  constructor(private readonly userService: UserService) {}
 
   @Get('current-user')
   getMe(@GetUser() user: User) {
@@ -22,8 +41,23 @@ export class UserController {
   }
 
   @Get()
-  findAll() {
-    return this.userService.findAll();
+  @UseGuards(JwtGuard, AbilitiesGuard)
+  @CheckAbilities((ability: AppAbility) =>
+    ability.can(Action.Read, Subject.User),
+  )
+  async findAll(@RequestAbility() ability: AppAbility) {
+    const users = await this.userService.findAll();
+
+    const filteredUsers = users.filter((user) =>
+      ability.can(Action.Read, subject(Subject.User, user)),
+    );
+
+    if (filteredUsers.length === 0)
+      throw new ForbiddenException(
+        'You are not authorized to access this resource',
+      );
+
+    return filteredUsers;
   }
 
   @Get(':id')

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
+import { CaslModule } from '../casl/casl.module';
 
 @Module({
+  imports: [CaslModule],
   controllers: [UserController],
   providers: [UserService],
 })

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,15 +1,34 @@
 import { Injectable } from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class UserService {
+  constructor(private prisma: PrismaService) {}
   create(createUserDto: CreateUserDto) {
     return 'This action adds a new user';
   }
 
-  findAll() {
-    return `This action returns all user`;
+  async findAll() {
+    const users = await this.prisma.user.findMany({
+      select: {
+        id: true,
+        email: true,
+        firstName: true,
+        lastName: true,
+        phoneNumber: true,
+        dateOfBirth: true,
+        role: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return users;
   }
 
   findOne(id: number) {

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -32,12 +32,10 @@ describe('User (e2e)', () => {
 
   afterAll(async () => {
     await teardownE2ETest();
-  })
+  });
 
   it('should return 401 if user is not authenticated', async () => {
-    await request(app.getHttpServer())
-      .get('/user/current-user')
-      .expect(401);
+    await request(app.getHttpServer()).get('/user/current-user').expect(401);
   });
 
   it('should return current user with valid token', async () => {
@@ -63,4 +61,10 @@ describe('User (e2e)', () => {
       .expect(401);
   });
 
+  it('should return 403 forbidden access', async () => {
+    await request(app.getHttpServer())
+      .get('/user')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(403);
+  });
 });


### PR DESCRIPTION
- Fixed `seedUserData` to use `'User'` model instead of `'Admin'`, ensuring user data is correctly seeded into the database.
- Updated Prisma schema to include `Role` and `Permission` models.
- Implemented CASL-based authorization:
  - Created CASL Ability Factory and CASL Module.
  - Added `CheckAbility` decorator and `AbilitiesGuard`.
  - Introduced `RequestAbility` decorator to retrieve abilities from requests.
- Enhanced seeding with roles (`admin`, `team_lead`, `user`) and permissions:
  - Set `user` as the default role.
  - Added two additional users for non-production testing.
- Created `findAll` route in `UserController`:
  - Restricted access to `admin` role via permissions.
  - Tested with Postman and added a e2e test to verify `403 Forbidden` for default users.

https://bloomteq-internship-team4.atlassian.net/browse/BT-51?atlOrigin=eyJpIjoiNmI0NjVkNTQ1MDRjNDEyN2JhMWQxOWJlY2YzMjZhMmUiLCJwIjoiaiJ9