### PR TITLE
add route for getting user by id and class-transformer entities for u…

### DIFF
--- a/src/role/entity/permission.entity.ts
+++ b/src/role/entity/permission.entity.ts
@@ -1,0 +1,34 @@
+import { Exclude, Expose } from 'class-transformer';
+
+export class PermissionEntity {
+  @Expose()
+  id: string;
+
+  @Expose()
+  action: string;
+
+  @Expose()
+  subject: string;
+
+  @Expose()
+  conditions?: any | null;
+
+  @Expose()
+  fields?: string[];
+
+  @Expose()
+  createdAt: Date;
+
+  @Expose()
+  updatedAt: Date;
+
+  @Exclude()
+  conditionHash: string | null;
+
+  @Exclude()
+  fieldsHash: string | null;
+
+  constructor(partial: Partial<PermissionEntity>) {
+    Object.assign(this, partial);
+  }
+}

--- a/src/role/entity/role.entity.ts
+++ b/src/role/entity/role.entity.ts
@@ -1,0 +1,30 @@
+import { Exclude, Expose, Type } from 'class-transformer';
+import { PermissionEntity } from './permission.entity';
+
+export class RoleEntity {
+  @Expose()
+  id: string;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  description?: string | null;
+
+  @Expose()
+  @Type(() => PermissionEntity)
+  permissions: PermissionEntity[];
+
+  @Expose()
+  createdAt: Date;
+
+  @Expose()
+  updatedAt: Date;
+
+  @Exclude()
+  isDefault: boolean;
+
+  constructor(partial: Partial<RoleEntity>) {
+    Object.assign(this, partial);
+  }
+}

--- a/src/role/type/permission.type.ts
+++ b/src/role/type/permission.type.ts
@@ -1,0 +1,9 @@
+export type Permission = {
+  id: string;
+  action: string;
+  subject: string;
+  conditions?: any | null;
+  fields?: string[];
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/role/type/role.type.ts
+++ b/src/role/type/role.type.ts
@@ -1,0 +1,10 @@
+import { Permission } from './permission.type';
+
+export type Role = {
+  id: string;
+  name: string;
+  description?: string | null;
+  permissions: Permission[];
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/user/entity/user.entity.ts
+++ b/src/user/entity/user.entity.ts
@@ -1,29 +1,43 @@
-import { Exclude, Expose } from 'class-transformer';
-import { Role } from '../../../prisma/generated/role/entities';
+import { Exclude, Expose, Type } from 'class-transformer';
+import { RoleEntity } from 'src/role/entity/role.entity';
 
 export class UserEntity {
+  @Expose()
   id: string;
+
+  @Expose()
   email: string;
+
+  @Expose()
   firstName: string;
+
+  @Expose()
   lastName: string;
+
+  @Expose()
   phoneNumber: string;
+
+  @Expose()
   dateOfBirth: Date;
+
+  @Expose()
   status: string;
+
+  @Expose()
+  createdAt: Date;
+
+  @Expose()
+  updatedAt: Date;
+
+  @Expose()
+  @Type(() => RoleEntity)
+  role: RoleEntity;
 
   @Exclude()
   firebaseUid: string;
 
   @Exclude()
   roleId: string;
-
-  @Exclude()
-  createdAt: Date;
-
-  @Exclude()
-  updatedAt: Date;
-
-  @Expose()
-  role: Role;
 
   constructor(partial: Partial<UserEntity>) {
     Object.assign(this, partial);

--- a/src/user/type/user.type.ts
+++ b/src/user/type/user.type.ts
@@ -1,4 +1,4 @@
-import { Role } from 'prisma/generated/role/entities';
+import { Role } from 'src/role/type/role.type';
 
 export type User = {
   id: string;
@@ -8,5 +8,7 @@ export type User = {
   phoneNumber: string;
   dateOfBirth: Date;
   status: string;
+  createdAt: Date;
+  updatedAt: Date;
   role: Role;
 };

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -53,6 +53,25 @@ export class UserController {
     return filteredUsers;
   }
 
+  @Get(':userId')
+  @CheckAbilities((ability: AppAbility) =>
+    ability.can(Action.Read, Subject.User),
+  )
+  async getUserById(
+    @Param('userId') userId: string,
+    @RequestAbility() ability: AppAbility,
+  ) {
+    const user = this.userService.getUserById(userId);
+
+    if (ability.cannot(Action.Read, subject(Subject.User, user))) {
+      throw new ForbiddenException(
+        'You are not authorized to access this resource',
+      );
+    }
+
+    return user;
+  }
+
   @Put(':userId/activate')
   @CheckAbilities((ability: AppAbility) =>
     ability.can(Action.Update, Subject.User, 'status'),


### PR DESCRIPTION
### What's Changed
- Created UserEntity, RoleEntity, and PermissionEntity using class-transformer to control field exposure
- Replaced direct return of Prisma results with serialized entity instances
- Added a new service method and controller route to get a user by ID
- Removed manual .select() logic from service/controller layers
- Ensured firebaseUid, conditionHash, and other sensitive/internal fields are excluded from the API response